### PR TITLE
refactor: enhance poker table layout

### DIFF
--- a/public/css/poker.css
+++ b/public/css/poker.css
@@ -1,0 +1,147 @@
+.poker-table {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.pot-display {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #ffd700;
+  color: #000;
+  padding: 10px 20px;
+  border-radius: 50%;
+  font-weight: bold;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+}
+
+.community-cards {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  gap: 8px;
+}
+
+.player-seats {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.player-seat {
+  position: absolute;
+  width: 120px;
+  text-align: center;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+  display: none;
+}
+
+.player-seat.active {
+  border: 2px solid #ffd700;
+}
+
+.player-seat .player-name {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.player-seat .player-chips {
+  color: #ffd700;
+  font-weight: bold;
+}
+
+.seat-0 { bottom: 5%; left: 50%; transform: translateX(-50%); }
+.seat-1 { bottom: 20%; left: 5%; }
+.seat-2 { bottom: 20%; right: 5%; }
+.seat-3 { top: 5%; left: 50%; transform: translateX(-50%); }
+.seat-4 { top: 20%; left: 5%; }
+.seat-5 { top: 20%; right: 5%; }
+
+.betting-controls {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, -20%);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.betting-controls input {
+  width: 80px;
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+.fold-button {
+  background: #e53935;
+  color: #fff;
+}
+
+.call-button {
+  background: #43a047;
+  color: #fff;
+}
+
+.raise-button {
+  background: #1e88e5;
+  color: #fff;
+}
+
+.bet-button {
+  background: #fb8c00;
+  color: #fff;
+}
+
+.fold-button,
+.call-button,
+.raise-button,
+.bet-button {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.hand-rankings {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  padding: 15px;
+  border-radius: 8px;
+  max-width: 200px;
+  display: none;
+}
+
+.hand-rankings.show {
+  display: block;
+}
+
+.hand-rankings-btn {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 8px 12px;
+  background: #2e7d32;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}

--- a/public/js/poker.js
+++ b/public/js/poker.js
@@ -954,7 +954,30 @@ class PokerClient {
                     <div class="player-bet">Bet: $${player.currentBet}</div>
                 `;
                 
-                playerList.appendChild(playerDiv);
+            playerList.appendChild(playerDiv);
+        });
+    }
+
+        // Update on-table player seats
+        const seatsContainer = document.getElementById('playerSeats');
+        if (seatsContainer) {
+            const seats = seatsContainer.querySelectorAll('.player-seat');
+            seats.forEach(seat => seat.style.display = 'none');
+
+            this.game.players.forEach((player, index) => {
+                const seat = seatsContainer.querySelector('.seat-' + index);
+                if (seat) {
+                    seat.innerHTML = `
+                        <div class="player-name">${player.name}</div>
+                        <div class="player-chips">$${player.chips}</div>
+                    `;
+                    seat.style.display = 'block';
+                    if (index === this.game.currentPlayer) {
+                        seat.classList.add('active');
+                    } else {
+                        seat.classList.remove('active');
+                    }
+                }
             });
         }
     }

--- a/public/poker.html
+++ b/public/poker.html
@@ -23,6 +23,7 @@
     <script src="/socket.io/socket.io.js"></script>
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/lobby-fixes.css">
+    <link rel="stylesheet" href="css/poker.css">
     <style>
         body {
             margin: 0;
@@ -378,11 +379,12 @@
 
     <div id="Game">
         <div class="poker-table">
+            <button id="handRankingsToggle" class="hand-rankings-btn">Hand Rankings</button>
             <div class="pot-display">
                 Pot: $<span id="potAmount">0</span>
             </div>
-            
-            <div class="hand-rankings">
+
+            <div class="hand-rankings" id="handRankings">
                 <h3>Hand Rankings</h3>
                 <ul>
                     <li>Royal Flush</li>
@@ -401,12 +403,21 @@
             <div class="community-cards" id="communityCards">
                 <!-- Community cards will be rendered here -->
             </div>
-            
+
+            <div class="player-seats" id="playerSeats">
+                <div class="player-seat seat-0"></div>
+                <div class="player-seat seat-1"></div>
+                <div class="player-seat seat-2"></div>
+                <div class="player-seat seat-3"></div>
+                <div class="player-seat seat-4"></div>
+                <div class="player-seat seat-5"></div>
+            </div>
+
             <div class="betting-controls" id="bettingControls" style="display: none;">
                 <button id="foldBtn" class="fold-button">Fold</button>
                 <button id="callBtn" class="call-button">Call $<span id="callAmount">0</span></button>
                 <button id="raiseBtn" class="raise-button">Raise</button>
-                <input type="number" id="betAmount" placeholder="Bet amount" style="padding: 10px; border: none; border-radius: 5px; width: 100px;">
+                <input type="number" id="betAmount" placeholder="Bet amount">
                 <button id="betBtn" class="bet-button">Bet</button>
             </div>
         </div>
@@ -443,6 +454,17 @@
                         document.body.classList.add('room-created');
                         console.log('🎮 Room-created class added');
                     }, 100);
+                });
+            }
+        });
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const rankingsBtn = document.getElementById('handRankingsToggle');
+            const rankings = document.getElementById('handRankings');
+            if (rankingsBtn && rankings) {
+                rankingsBtn.addEventListener('click', () => {
+                    rankings.classList.toggle('show');
                 });
             }
         });


### PR DESCRIPTION
## Summary
- Introduce poker-specific stylesheet to arrange table elements and players cleanly
- Add player seat container and hand ranking toggle in poker layout
- Update client logic to populate new player seat elements

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba7fbc47548328a8230dc983d5f3d0